### PR TITLE
SSH Public Key の fingerprint (MD5) を計算する関数

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *~
 .ghc.environment.*
 dist-newstyle/
+stack.yaml
+stack.yaml.lock

--- a/Crypto/SSH/PubKey.hs
+++ b/Crypto/SSH/PubKey.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Crypto.SSH.PubKey where
+
+import Crypto.Hash (Digest, MD5)
+import qualified Crypto.Hash as Crypto
+import Data.ByteArray.Encoding (Base (Base64), convertFromBase)
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as B
+
+-- | generate fingerprint by MD5 Hash
+fingerprint :: ByteString -> Maybe (Digest MD5)
+fingerprint content = do
+  body <- pubkeyBody content
+  bin  <- decode body
+  pure $ Crypto.hash bin
+
+pubkeyBody :: ByteString -> Maybe ByteString
+pubkeyBody content =
+  case B.split (B.head " ") content of
+    [header, body] | header == "ssh-rsa" && "AAAA" `B.isPrefixOf` body ->
+        Just body
+    _ ->
+        Nothing
+
+decode :: ByteString -> Maybe ByteString
+decode body =
+  case convertFromBase Base64 body of
+    Right bin | prefix `B.isPrefixOf` bin ->
+        Just bin
+    _ ->
+        Nothing
+  where
+    prefix = "\NUL\NUL\NUL\assh-rsa"

--- a/playground.cabal
+++ b/playground.cabal
@@ -22,8 +22,10 @@ library
     , Calc.TTG
     , UserData.Types
     , Generics.FieldName
+    , Crypto.SSH.PubKey
   -- other-modules:
   -- other-extensions:
   ghc-options: -Wall
   build-depends:       base, text, aeson, bytestring, double-conversion
+                     , memory, cryptonite
   default-language:    Haskell2010


### PR DESCRIPTION
https://github.com/settings/keys などで確認できる `:` 区切りの fingerprint を計算する関数です。

GitHub に設定してる公開鍵を使ってごにょごにょするプログラムを作る時にできたコードです。
プログラム自体はまだ未完成なので先にこれだけを playground に出そうかなと。
crypto 関連の例って意外と少ないんであっても良いかなっと。

.gitignore に stack.yaml 系を足したのは、手元では stack を使って試したけど設定ファイルは push しなくていいかなとなったためです。

手元では stack と cabal (docker) の両方でやってます:

```
// cabal
$ docker run -it --rm -v `pwd`:/work -w /work haskell:8.8 /bin/bash -c "cabal v2-update && cabal v2-build"

// stack
$ stack init
$ stack build
```